### PR TITLE
Fix unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 - 'pypy'
 install:
 - pip install tox

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -88,10 +88,10 @@ def expected_data():
             }
         },
         {
-            "outcome": "xpassed",
+            "outcome": "passed",
             "call": {
                 "xfail_reason": "testing xfail",
-                "outcome": "xpassed",
+                "outcome": "passed",
                 "name": "call",
                 "stdout": "I am xfailed but passing\n"
             },
@@ -214,9 +214,8 @@ def test_report(testdir, expected_data):
     assert report['summary']['num_tests'] == 7
     assert report['summary']['xfailed'] == 1
     assert report['summary']['failed'] == 1
-    assert report['summary']['passed'] == 2
+    assert report['summary']['passed'] == 3
     assert report['summary']['error'] == 2
-    assert report['summary']['xpassed'] == 1
     assert report['summary']['skipped'] == 1
 
     # tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.org/en/latest/
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
- Pytest sets unexpected passing tests to an outcome of `passed` now instead of `xpassed`.
- Bump tox env, 3.3 is no longer supported and 3.6 is latest.