### PR TITLE
Allow for use as plugin with inline pytest invocation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,21 @@ or you can set the jsonapi flag in an ini file::
 Note that the value of the ini var can be anything. Presence alone will cause
 it to be true.
 
+The json report plugin can also be used with inline Pytest execution.
+
+.. code-block:: python
+
+  import pytest
+  from pytest_json.report import JSONReport
+
+  plugin = JSONReport()
+  result = pytest.main(['/tmp/test_file.py'], plugins=[plugin])
+
+  assert plugin.json_report['report']['summary']['passed'] == 1
+
+The report dictionary is accesible on the plugin object following the test run
+, `plugin.json_report`.
+
 Adding to environment
 ---------------------
 

--- a/pytest_json/report.py
+++ b/pytest_json/report.py
@@ -16,9 +16,10 @@ if not PY3:
 
 class JSONReport(object):
     def __init__(self, json_path=None, jsonapi=False):
-        if json_path:
-            self.json_path = os.path.abspath(
-                os.path.expanduser(os.path.expandvars(json_path)))
+        self.json_path = os.path.abspath(
+            os.path.expanduser(os.path.expandvars(json_path))
+        ) if json_path else json_path
+
         self.jsonapi = jsonapi
         self.nodes = {}
         self.summary = {}

--- a/pytest_json/report.py
+++ b/pytest_json/report.py
@@ -15,9 +15,10 @@ if not PY3:
 
 
 class JSONReport(object):
-    def __init__(self, json_path, jsonapi):
-        self.json_path = os.path.abspath(
-            os.path.expanduser(os.path.expandvars(json_path)))
+    def __init__(self, json_path=None, jsonapi=False):
+        if json_path:
+            self.json_path = os.path.abspath(
+                os.path.expanduser(os.path.expandvars(json_path)))
         self.jsonapi = jsonapi
         self.nodes = {}
         self.summary = {}
@@ -202,11 +203,14 @@ class JSONReport(object):
         else:
             report = self._default_report(env, tests, created_at)
 
-        if not os.path.exists(os.path.dirname(self.json_path)):
-            os.makedirs(os.path.dirname(self.json_path))
+        if self.json_path:
+            if not os.path.exists(os.path.dirname(self.json_path)):
+                os.makedirs(os.path.dirname(self.json_path))
 
-        with open(self.json_path, 'w', encoding='utf-8') as f:
-            f.write(json.dumps(report))
+            with open(self.json_path, 'w', encoding='utf-8') as f:
+                f.write(json.dumps(report))
+        else:
+            self.json_report = report
 
     def pytest_terminal_summary(self, terminalreporter):
         terminalreporter.write_sep('-', 'generated json report: {0}'.format(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -410,3 +410,4 @@ def test_help_message(testdir):
         '*json_report (string)*where to store the JSON report',
         '*jsonapi (string)*if present (any value), export JSON report as jsonapi',
     ])
+

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pytest_json.report import JSONReport
+
+
+def test_inline_plugin(testdir):
+    """Test json results output."""
+    test_file = testdir.makepyfile("""
+        def test_foo():
+            assert 1 == 1
+    """)
+
+    plugin = JSONReport()
+    result = pytest.main([test_file.strpath], plugins=[plugin])
+
+    assert result == 0
+    assert plugin.json_report['report']['summary']['passed'] == 1


### PR DESCRIPTION
- Set instance attr of json_report instead of writing report to file.

Fixes #4 